### PR TITLE
make up-item smart

### DIFF
--- a/direx.el
+++ b/direx.el
@@ -414,9 +414,9 @@ mouse-2: find this node in other window"))
            (equal (direx:file-full-name x) (direx:file-full-name y)))))
 
 (defmethod direx:node-parent ((file direx:file))
-  (direx:awhen (file-name-directory (directory-file-name (direx:file-full-name file)))
-    (when (file-directory-p it)
-      (direx:make-directory it))))
+  (let ((parent (file-name-directory (directory-file-name (direx:file-full-name file)))))
+    (when (and parent (file-directory-p parent))
+      (direx:make-directory parent))))
 
 (defclass direx:regular-file (direx:file direx:leaf)
   ())


### PR DESCRIPTION
I suppose it's better to move the parent directory if the root directory of the direx buffer has a parent directory.

I tested that the changed behavior of this pull request is up to my expectation.
But, I'm not sure whether the following code in `direx:up-item` is OK or not.

``` lisp
(erase-buffer)
(direx:add-root-into-buffer it (current-buffer))
(rename-buffer (direx:tree-name it) t))
```

Does this code give any bad effect to the other function of direx?

Best regards.
