### PR TITLE
fix direx:next-sibling-item-1 for ignoring the invisible siblings

### DIFF
--- a/direx.el
+++ b/direx.el
@@ -726,9 +726,8 @@ mouse-2: find this node in other window"))
   (loop with parent = (direx:item-parent item)
         with siblings = (when parent (direx:item-children parent))
         with ordered-siblings = (if (plusp arg) siblings (reverse siblings))
-        with next-siblings = (memq item ordered-siblings)
-        with idx = 1
-        with sibling = (nth idx next-siblings)
+        with next-siblings = (cdr (memq item ordered-siblings))
+        with sibling = (when next-siblings (pop next-siblings))
         with point = (point)
         with item
         while (and sibling
@@ -738,7 +737,7 @@ mouse-2: find this node in other window"))
                 (direx:item-visible-p item))
         return (direx:move-to-item-name-part item)
         else if (eq item sibling)
-        do (setq sibling (nth (incf idx) next-siblings))
+        do (setq sibling (when next-siblings (pop next-siblings)))
         finally
         (goto-char point)
         (error "No sibling")))


### PR DESCRIPTION
I've made `direx:next-sibling-item-1` ignore the invisible siblings, as `direx:next-item` do.
