### PR TITLE
fix regression in direx:make-buffer

### DIFF
--- a/direx.el
+++ b/direx.el
@@ -707,10 +707,7 @@ mouse-2: find this node in other window"))
     buffer))
 
 (defmethod direx:make-buffer ((dir direx:directory))
-  (with-current-buffer (if (fboundp 'cl-call-next-method)
-                           (cl-call-next-method)
-                         (with-no-warnings
-                           (call-next-method)))
+  (with-current-buffer (call-next-method)
     (set (make-local-variable 'dired-directory)
          (direx:file-full-name dir))
     (current-buffer)))


### PR DESCRIPTION
```
Always use `call-next-method'.  `cl-call-next-method' should
only be used inside `cl-defmethod' but not inside `defmethod'.
```

Sorry about that.